### PR TITLE
Fix typo in #suffix

### DIFF
--- a/link_iframe_formatter.module
+++ b/link_iframe_formatter.module
@@ -74,7 +74,7 @@ function link_iframe_formatter_field_formatter_view($entity_type, $entity, $fiel
       $elements[$delta] = array(
         '#type' => 'markup',
         '#prefix' => '<iframe height="' . $height . '" width="' . $width . '" name="' . $name . '" src="' . $src . '">',
-        '#sufix' => '</iframe>',
+        '#suffix' => '</iframe>',
       );
     }
   }


### PR DESCRIPTION
I noticed the closing tag was not printed (and it caused the following markup to not but interpreted correctly by the browser).
It seems to be because of a typo in `#suffix`.